### PR TITLE
Sort addon category list alphabetically by name

### DIFF
--- a/src/main-process/Game/get-game-data-sync.js
+++ b/src/main-process/Game/get-game-data-sync.js
@@ -6,7 +6,8 @@ ipcMain.on('get-game-data', (event, gameId) => {
 });
 
 ipcMain.on('get-game-addon-categories', (event, gameId) => {
-    event.returnValue = storageService.getGameData(gameId.toString()).categories;
+    const categories = storageService.getGameData(gameId.toString()).categories;
+    event.returnValue = categories.sort((a, b) => (a.name > b.name) ? 1 : -1);
 });
 
 ipcMain.on('get-game-addon-version', (event, gameId, gameVersion) => {


### PR DESCRIPTION
The items fed into the Category dropdown will now be sorted
alphabetically by their `name` attribute. As an example, this list
may now look like:
* All
* Achievements
* Action Bars
* Alchemy
* ...

rather than:
* All
* Chat & Communication
* Auction & Economy
* Audio & Video
* PvP
* ...

![sorted-categories](https://user-images.githubusercontent.com/410310/99888426-b7d69f80-2c1a-11eb-8c2f-f0eb1175de34.PNG)


Implements #8